### PR TITLE
Refactor file writing out of the discovery module

### DIFF
--- a/src/aiven-service-discovery/main.go
+++ b/src/aiven-service-discovery/main.go
@@ -17,6 +17,7 @@ import (
 	f "github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/fetcher"
 	i "github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/integrator"
 	r "github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/resolver"
+	w "github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/writer"
 )
 
 const (
@@ -79,9 +80,11 @@ func main() {
 		log.Fatalf("Could not create integrator: %s", err)
 	}
 
+	writer := w.NewWriter(serviceDiscoveryTargetPath, logger)
+
 	discoverer, err := d.NewDiscoverer(
-		aivenProject, serviceDiscoveryTargetPath,
-		fetcher, r.NewResolver(),
+		aivenProject,
+		fetcher, r.NewResolver(), writer,
 		logger,
 	)
 	if err != nil {

--- a/src/aiven-service-discovery/pkg/discoverer/discoverer.go
+++ b/src/aiven-service-discovery/pkg/discoverer/discoverer.go
@@ -174,7 +174,7 @@ func (d *discoverer) discoverAndWrite() {
 	targets := d.performDNSDiscovery(servicesWithPrometheus)
 	lsession.Info("targets", lager.Data{"targets": targets})
 	DiscovererWriteTargetsTotal.Inc()
-	d.writer.Write(targets)
+	d.writer.WritePrometheusTargetConfigs(targets)
 }
 
 func (d *discoverer) loop() {

--- a/src/aiven-service-discovery/pkg/discoverer/discoverer_test.go
+++ b/src/aiven-service-discovery/pkg/discoverer/discoverer_test.go
@@ -32,7 +32,7 @@ type fakeWriter struct {
 	mostRecentWrite []writer.PrometheusTargetConfig
 }
 
-func (w *fakeWriter) Write(targets []writer.PrometheusTargetConfig) {
+func (w *fakeWriter) WritePrometheusTargetConfigs(targets []writer.PrometheusTargetConfig) {
 	w.mostRecentWrite = targets
 }
 

--- a/src/aiven-service-discovery/pkg/discoverer/metrics.go
+++ b/src/aiven-service-discovery/pkg/discoverer/metrics.go
@@ -5,14 +5,9 @@ import (
 )
 
 var (
-	DiscovererWriteTargetsErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "discoverer_write_targets_errors_total",
-		Help: "Counter of total number of target file write failures",
-	})
-
 	DiscovererWriteTargetsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "discoverer_write_targets_total",
-		Help: "Counter of total number of target file writes",
+		Help: "Counter of total number of writes invoked",
 	})
 
 	DiscovererDNSDiscoveryErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -27,7 +22,6 @@ var (
 )
 
 func initMetrics() {
-	prometheus.MustRegister(DiscovererWriteTargetsErrorsTotal)
 	prometheus.MustRegister(DiscovererWriteTargetsTotal)
 
 	prometheus.MustRegister(DiscovererDNSDiscoveryErrorsTotal)

--- a/src/aiven-service-discovery/pkg/writer/metrics.go
+++ b/src/aiven-service-discovery/pkg/writer/metrics.go
@@ -1,0 +1,22 @@
+package writer
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	WriterWriteTargetsErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "writer_write_targets_errors_total",
+		Help: "Counter of total number of target file write failures",
+	})
+
+	WriterWriteTargetsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "writer_write_targets_total",
+		Help: "Counter of total number of target file writes",
+	})
+)
+
+func initMetrics() {
+	prometheus.MustRegister(WriterWriteTargetsErrorsTotal)
+	prometheus.MustRegister(WriterWriteTargetsTotal)
+}

--- a/src/aiven-service-discovery/pkg/writer/prometheus_target_config.go
+++ b/src/aiven-service-discovery/pkg/writer/prometheus_target_config.go
@@ -1,10 +1,10 @@
-package discoverer
+package writer
 
 import (
 	"net"
 )
 
-type prometheusTargetConfigLabels struct {
+type PrometheusTargetConfigLabels struct {
 	ServiceName string `json:"aiven_service_name"`
 	ServiceType string `json:"aiven_service_type"`
 	Hostname    string `json:"aiven_hostname"`
@@ -13,7 +13,7 @@ type prometheusTargetConfigLabels struct {
 	NodeCount   string `json:"aiven_node_count"`
 }
 
-type prometheusTargetConfig struct {
+type PrometheusTargetConfig struct {
 	Targets []net.IP                     `json:"targets"`
-	Labels  prometheusTargetConfigLabels `json:"labels"`
+	Labels  PrometheusTargetConfigLabels `json:"labels"`
 }

--- a/src/aiven-service-discovery/pkg/writer/writer.go
+++ b/src/aiven-service-discovery/pkg/writer/writer.go
@@ -1,0 +1,65 @@
+package writer
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"code.cloudfoundry.org/lager"
+)
+
+func init() {
+	initMetrics()
+}
+
+type Writer interface {
+	Write(targets []PrometheusTargetConfig)
+}
+
+type writer struct {
+	filePath string
+
+	logger lager.Logger
+}
+
+func NewWriter(
+	filePath string,
+	logger lager.Logger,
+) Writer {
+	lsession := logger.Session("writer", lager.Data{"file-path": filePath})
+
+	return &writer{
+		filePath: filePath,
+
+		logger: lsession,
+	}
+}
+
+func (w *writer) Write(targets []PrometheusTargetConfig) {
+	lsession := w.logger.Session("write")
+	lsession.Info("begin")
+	defer lsession.Info("end")
+
+	WriterWriteTargetsTotal.Inc()
+
+	targetsAsJSON, err := json.Marshal(targets)
+
+	if err != nil {
+		lsession.Error(
+			"err-marshal-json-targets",
+			err, lager.Data{"targets": targets},
+		)
+
+		WriterWriteTargetsErrorsTotal.Inc()
+
+		return
+	}
+
+	err = ioutil.WriteFile(w.filePath, targetsAsJSON, 0644)
+	if err != nil {
+		lsession.Error("err-write-json-targets", err)
+
+		WriterWriteTargetsErrorsTotal.Inc()
+
+		return
+	}
+}

--- a/src/aiven-service-discovery/pkg/writer/writer.go
+++ b/src/aiven-service-discovery/pkg/writer/writer.go
@@ -12,7 +12,7 @@ func init() {
 }
 
 type Writer interface {
-	Write(targets []PrometheusTargetConfig)
+	WritePrometheusTargetConfigs(targets []PrometheusTargetConfig)
 }
 
 type writer struct {
@@ -34,8 +34,8 @@ func NewWriter(
 	}
 }
 
-func (w *writer) Write(targets []PrometheusTargetConfig) {
-	lsession := w.logger.Session("write")
+func (w *writer) WritePrometheusTargetConfigs(targets []PrometheusTargetConfig) {
+	lsession := w.logger.Session("write-prometheus-target-configs")
 	lsession.Info("begin")
 	defer lsession.Info("end")
 

--- a/src/aiven-service-discovery/pkg/writer/writer_suite_test.go
+++ b/src/aiven-service-discovery/pkg/writer/writer_suite_test.go
@@ -1,0 +1,13 @@
+package writer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDiscoverer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Writer Suite")
+}

--- a/src/aiven-service-discovery/pkg/writer/writer_test.go
+++ b/src/aiven-service-discovery/pkg/writer/writer_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Writer", func() {
 
 	It("should keep the file up to date with targets", func() {
 		By("writing the targets")
-		w.Write([]writer.PrometheusTargetConfig{
+		w.WritePrometheusTargetConfigs([]writer.PrometheusTargetConfig{
 			{
 				Targets: []net.IP{net.IPv4(1, 2, 3, 4)},
 				Labels: writer.PrometheusTargetConfigLabels{
@@ -93,7 +93,7 @@ var _ = Describe("Writer", func() {
         }]`))
 
 		By("updating the targets")
-		w.Write([]writer.PrometheusTargetConfig{
+		w.WritePrometheusTargetConfigs([]writer.PrometheusTargetConfig{
 			{
 				Targets: []net.IP{
 					net.IPv4(1, 2, 3, 4),
@@ -125,7 +125,7 @@ var _ = Describe("Writer", func() {
         }]`))
 
 		By("updating the targets several times")
-		w.Write([]writer.PrometheusTargetConfig{
+		w.WritePrometheusTargetConfigs([]writer.PrometheusTargetConfig{
 			{
 				Targets: []net.IP{
 					net.IPv4(1, 2, 3, 4),
@@ -181,7 +181,7 @@ var _ = Describe("Writer", func() {
         }]`))
 
 		By("updating even if there are no services")
-		w.Write([]writer.PrometheusTargetConfig{})
+		w.WritePrometheusTargetConfigs([]writer.PrometheusTargetConfig{})
 		Eventually(func() []byte {
 			contents, _ := ioutil.ReadFile(target)
 			return contents

--- a/src/aiven-service-discovery/pkg/writer/writer_test.go
+++ b/src/aiven-service-discovery/pkg/writer/writer_test.go
@@ -1,0 +1,198 @@
+package writer_test
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/lager"
+
+	h "github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/testhelpers"
+	"github.com/alphagov/paas-observability-release/src/aiven-service-discovery/pkg/writer"
+)
+
+const (
+	evTimeout  = "5s"
+	evInterval = "10ms"
+
+	ctlyTimeout  = "500ms"
+	ctlyInterval = "10ms"
+)
+
+var _ = Describe("Writer", func() {
+	var (
+		target string
+		w      writer.Writer
+
+		logger lager.Logger
+
+		writerWriteTargetsTotal       float64
+		writerWriteTargetsErrorsTotal float64
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		targetFile, err := ioutil.TempFile("", "targets")
+		Expect(err).NotTo(HaveOccurred())
+		target = targetFile.Name()
+		err = targetFile.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		logger = lager.NewLogger("writer-test")
+		logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.INFO))
+
+		w = writer.NewWriter(target, logger)
+
+		By("setting the metric values before each test")
+		writerWriteTargetsTotal = h.CurrentMetricValue(
+			writer.WriterWriteTargetsTotal,
+		)
+		writerWriteTargetsErrorsTotal = h.CurrentMetricValue(
+			writer.WriterWriteTargetsErrorsTotal,
+		)
+	})
+
+	AfterEach(func() {
+		if target != "" {
+			os.Remove(target)
+		}
+	})
+
+	It("should keep the file up to date with targets", func() {
+		By("writing the targets")
+		w.Write([]writer.PrometheusTargetConfig{
+			{
+				Targets: []net.IP{net.IPv4(1, 2, 3, 4)},
+				Labels: writer.PrometheusTargetConfigLabels{
+					ServiceName: "a-service",
+					ServiceType: "elasticsearch",
+					Hostname:    "an-instance.aivencloud.com",
+					Plan:        "tiny-6.x",
+					Cloud:       "aws-eu-west-1",
+					NodeCount:   "3",
+				},
+			},
+		})
+		Eventually(func() []byte {
+			contents, _ := ioutil.ReadFile(target)
+			return contents
+		}, evTimeout, evInterval).Should(MatchJSON(`[{
+            "targets": ["1.2.3.4"],
+            "labels": {
+                "aiven_service_name": "a-service",
+                "aiven_service_type": "elasticsearch",
+                "aiven_hostname": "an-instance.aivencloud.com",
+                "aiven_plan": "tiny-6.x",
+                "aiven_cloud": "aws-eu-west-1",
+                "aiven_node_count": "3"
+            }
+        }]`))
+
+		By("updating the targets")
+		w.Write([]writer.PrometheusTargetConfig{
+			{
+				Targets: []net.IP{
+					net.IPv4(1, 2, 3, 4),
+					net.IPv4(4, 3, 2, 1),
+				},
+				Labels: writer.PrometheusTargetConfigLabels{
+					ServiceName: "a-service",
+					ServiceType: "elasticsearch",
+					Hostname:    "an-instance.aivencloud.com",
+					Plan:        "tiny-6.x",
+					Cloud:       "aws-eu-west-1",
+					NodeCount:   "3",
+				},
+			},
+		})
+		Eventually(func() []byte {
+			contents, _ := ioutil.ReadFile(target)
+			return contents
+		}, evTimeout, evInterval).Should(MatchJSON(`[{
+            "targets": ["1.2.3.4", "4.3.2.1"],
+            "labels": {
+                "aiven_service_name": "a-service",
+                "aiven_service_type": "elasticsearch",
+                "aiven_hostname": "an-instance.aivencloud.com",
+                "aiven_plan": "tiny-6.x",
+                "aiven_cloud": "aws-eu-west-1",
+                "aiven_node_count": "3"
+            }
+        }]`))
+
+		By("updating the targets several times")
+		w.Write([]writer.PrometheusTargetConfig{
+			{
+				Targets: []net.IP{
+					net.IPv4(1, 2, 3, 4),
+					net.IPv4(4, 3, 2, 1),
+				},
+				Labels: writer.PrometheusTargetConfigLabels{
+					ServiceName: "a-service",
+					ServiceType: "elasticsearch",
+					Hostname:    "an-instance.aivencloud.com",
+					Plan:        "tiny-6.x",
+					Cloud:       "aws-eu-west-1",
+					NodeCount:   "3",
+				},
+			},
+			{
+				Targets: []net.IP{
+					net.IPv4(1, 2, 3, 4),
+					net.IPv4(3, 9, 6, 4),
+				},
+				Labels: writer.PrometheusTargetConfigLabels{
+					ServiceName: "another-service",
+					ServiceType: "elasticsearch",
+					Hostname:    "another-instance.aivencloud.com",
+					Plan:        "tiny-7.x",
+					Cloud:       "aws-eu-west-1",
+					NodeCount:   "2",
+				},
+			},
+		})
+		Eventually(func() []byte {
+			contents, _ := ioutil.ReadFile(target)
+			return contents
+		}, evTimeout, evInterval).Should(MatchJSON(`[{
+            "targets": ["1.2.3.4", "4.3.2.1"],
+            "labels": {
+                "aiven_service_name": "a-service",
+                "aiven_service_type": "elasticsearch",
+                "aiven_hostname": "an-instance.aivencloud.com",
+                "aiven_plan": "tiny-6.x",
+                "aiven_cloud": "aws-eu-west-1",
+                "aiven_node_count": "3"
+            }
+        }, {
+            "targets": ["1.2.3.4", "3.9.6.4"],
+            "labels": {
+                "aiven_service_name": "another-service",
+                "aiven_service_type": "elasticsearch",
+                "aiven_hostname": "another-instance.aivencloud.com",
+                "aiven_plan": "tiny-7.x",
+                "aiven_cloud": "aws-eu-west-1",
+                "aiven_node_count": "2"
+            }
+        }]`))
+
+		By("updating even if there are no services")
+		w.Write([]writer.PrometheusTargetConfig{})
+		Eventually(func() []byte {
+			contents, _ := ioutil.ReadFile(target)
+			return contents
+		}, evTimeout, evInterval).Should(MatchJSON(`[]`))
+
+		By("checking the metrics")
+		Expect(writer.WriterWriteTargetsTotal).To(
+			h.MetricIncrementedBy(writerWriteTargetsTotal, "==", 4),
+		)
+		Expect(writer.WriterWriteTargetsErrorsTotal).To(
+			h.MetricIncrementedBy(writerWriteTargetsErrorsTotal, "==", 0),
+		)
+	})
+})


### PR DESCRIPTION
## What

Until now the `aiven-service-discovery/pkg/discovery` Go module has done two things:

1. Done DNS resolution to list Prometheus endpoint IPs in Aiven
2. Written the results to a file.

This commit divides those responsibilities, allowing for other uses to be made of the endpoint IPs. A new `Writer` interface and package is added, and used to preserve the existing behaviour of the `aiven-service-discovery` BOSH Release.

This change should allow reusing `aiven-service-discovery` when building other software that interacts with Aiven. In particular, a tenant-facing Prometheus endpoint providing Elasticsearch metrics.

## How to review

The `aiven-service-discovery` tests pass but the BOSH release still needs trying out.

## Who can review

Not @46bit.